### PR TITLE
Stop creating draft invoices when adding first item

### DIFF
--- a/posawesome/public/js/posapp/components/pos/Invoice.vue
+++ b/posawesome/public/js/posapp/components/pos/Invoice.vue
@@ -777,13 +777,10 @@ export default {
           new_item.rate = rate;
           new_item.price_list_rate = rate;
           new_item.base_rate = rate;
-        this.items.push(new_item);
+          this.items.push(new_item);
         }
       }
-      
-      if (this.items.length === 1 && !this.invoice_doc) {
-        this.create_draft_invoice();
-      }
+
     },
     generateRowId() {
       return Date.now().toString(36) + Math.random().toString(36).substr(2);


### PR DESCRIPTION
## Summary
- prevent the POS invoice component from creating a draft invoice immediately after the first item is added so that drafts are only generated during the payment flow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2bb41dfb48326bf70f11a8f218eca