### PR TITLE
Keep POS navbar visible and make item selector scrollable

### DIFF
--- a/posawesome/public/js/posapp/components/Navbar.vue
+++ b/posawesome/public/js/posapp/components/Navbar.vue
@@ -287,9 +287,13 @@ export default {
 }
 
 .app-navbar {
+  /* Keep navbar pinned while scrolling */
   width: 100%;
   height: 40px;
-  z-index: 1000 !important;
+  position: sticky;
+  top: 0;
+  left: 0;
+  z-index: 1100 !important;
 }
 
 .invoice-number-badge {

--- a/posawesome/public/js/posapp/components/Navbar.vue
+++ b/posawesome/public/js/posapp/components/Navbar.vue
@@ -1,7 +1,7 @@
 <template>
   <!-- ===== TEMPLATE SECTION 1: MAIN CONTAINER ===== -->
   <nav>
-    <v-app-bar app height="40" class="elevation-2">
+    <v-app-bar app height="40" class="elevation-2 app-navbar">
       <!-- <v-app-bar-nav-icon
         @click.stop="drawer = !drawer"
         class="grey--text"
@@ -286,10 +286,10 @@ export default {
   margin-top: 0px;
 }
 
-.elevation-2 {
-  width: 1024px;
-  height: 768px;
-  z-index: 0 !important;
+.app-navbar {
+  width: 100%;
+  height: 40px;
+  z-index: 1000 !important;
 }
 
 .invoice-number-badge {

--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -1,7 +1,7 @@
 <template>
   <!-- ===== TEMPLATE SECTION 1: MAIN CONTAINER ===== -->
-  <!-- Fixed-height wrapper keeps scroll inside -->
-  <div class="selector-wrapper">
+  <!-- Lightweight shell keeps layout predictable -->
+  <div class="selector-shell">
 
   <!-- Filters and counters (no extra top margin) -->
     <v-card class="cards mb-2 pa-2 grey lighten-5">
@@ -43,7 +43,7 @@
         top
         color="info"
       ></v-progress-linear>
-  <v-row class="items px-2 py-1" style="flex: 1; min-height: 0;">
+      <v-row class="items-row px-2 py-1" style="flex: 1; min-height: 0;">
         <!-- Barcode search field -->
         <v-col cols="6" class="pb-0 mb-2">
           <v-text-field
@@ -104,9 +104,9 @@
             hide-details
           ></v-checkbox>
         </v-col>
-        <v-col cols="12" class="pt-0 mt-0 d-flex flex-column flex-grow-1">
+        <v-col cols="12" class="pt-0 mt-0 items-shell">
           <div
-            class="items-panel d-flex flex-column flex-grow-1"
+            class="items-shell__body"
             v-if="items_view == 'card'"
           >
             <!-- Scroll wrapper keeps card grid inside selector -->
@@ -164,7 +164,7 @@
             </div>
           </div>
           <div
-            class="items-panel d-flex flex-column flex-grow-1"
+            class="items-shell__body"
             v-if="items_view == 'list'"
           >
             <!-- Scroll wrapper keeps table height capped -->
@@ -1109,13 +1109,11 @@ export default {
 </script>
 
 <style scoped>
-.selector-wrapper {
-  /* Keep selector column inside viewport */
+.selector-shell {
+  /* Allow the selector column to expand naturally */
   display: flex;
   flex-direction: column;
-  height: calc(100vh - 64px);
-  max-height: calc(100vh - 64px);
-  overflow: hidden;
+  height: 100%;
 }
 
 .item-card {
@@ -1206,21 +1204,34 @@ export default {
 }
 
 .selection {
-  /* Let the selector card fill the wrapper */
+  /* Keep the card pinned while the items area scrolls */
   display: flex;
   flex-direction: column;
   flex: 1 1 auto;
   min-height: 0;
   overflow: hidden;
+  max-height: calc(100vh - 120px);
 }
 
-.items {
+
+.items-row {
+  /* Let the row containing inputs + list stretch */
   flex: 1 1 auto !important;
   min-height: 0 !important;
 }
 
-.items-panel {
-  /* Panel keeps search zone fixed while body flexes */
+.items-shell {
+  /* Reserve vertical space for the results panel */
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+.items-shell__body {
+  /* Split card/list view from the filters */
+  display: flex;
+  flex-direction: column;
   flex: 1 1 auto;
   min-height: 0;
 }
@@ -1229,9 +1240,8 @@ export default {
   /* Scroll area for the grid/list */
   flex: 1 1 auto;
   min-height: 0;
-  height: 100%;
   overflow-y: auto;
-  max-height: 100%;
+  width: 100%;
   padding-right: 4px;
   padding-bottom: 8px;
   overscroll-behavior: contain;
@@ -1246,16 +1256,14 @@ export default {
 }
 
 @media (max-width: 960px) {
-  .selector-wrapper {
-    height: calc(100vh - 112px);
-    max-height: calc(100vh - 112px);
+  .selection {
+    max-height: calc(100vh - 168px);
   }
 }
 
 @media (max-width: 600px) {
-  .selector-wrapper {
-    height: calc(100vh - 160px);
-    max-height: calc(100vh - 160px);
+  .selection {
+    max-height: calc(100vh - 208px);
   }
 }
 

--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -33,7 +33,7 @@
     </v-card>
 
     <v-card
-      class="selection mx-auto grey lighten-5 d-flex flex-column flex-grow-1"
+      class="selection grey lighten-5 d-flex flex-column flex-grow-1"
       style="min-height: 0;"
     >
       <v-progress-linear
@@ -1204,12 +1204,15 @@ export default {
 }
 
 .selection {
-  /* Keep the card pinned while the items area scrolls */
+  /* Keep selector full-width while capping height */
   display: flex;
   flex-direction: column;
   flex: 1 1 auto;
   min-height: 0;
   overflow: hidden;
+  width: 100%;
+  max-width: none;
+  height: calc(100vh - 120px);
   max-height: calc(100vh - 120px);
 }
 
@@ -1226,6 +1229,7 @@ export default {
   flex-direction: column;
   flex: 1 1 auto;
   min-height: 0;
+  overflow: hidden;
 }
 
 .items-shell__body {
@@ -1240,6 +1244,8 @@ export default {
   /* Scroll area for the grid/list */
   flex: 1 1 auto;
   min-height: 0;
+  height: 100%;
+  max-height: 100%;
   overflow-y: auto;
   width: 100%;
   padding-right: 4px;
@@ -1257,12 +1263,14 @@ export default {
 
 @media (max-width: 960px) {
   .selection {
+    height: calc(100vh - 168px);
     max-height: calc(100vh - 168px);
   }
 }
 
 @media (max-width: 600px) {
   .selection {
+    height: calc(100vh - 208px);
     max-height: calc(100vh - 208px);
   }
 }

--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -105,19 +105,24 @@
           ></v-checkbox>
         </v-col>
         <v-col cols="12" class="pt-0 mt-0 d-flex flex-column flex-grow-1">
-          <div class="items d-flex flex-column flex-grow-1" v-if="items_view == 'card'">
-            <v-row dense class="items-scrollable">
-              <v-col
-                v-for="(item, idx) in filtred_items"
-                :key="idx"
-                xl="2"
-                lg="3"
-                md="4"
-                sm="6"
-                cols="6"
-                min-height="50"
-              >
-                <v-card hover="hover" @click="add_item(item)" class="item-card">
+          <div
+            class="items-panel d-flex flex-column flex-grow-1"
+            v-if="items_view == 'card'"
+          >
+            <!-- Scroll wrapper keeps card grid inside selector -->
+            <div class="items-scrollable">
+              <v-row dense>
+                <v-col
+                  v-for="(item, idx) in filtred_items"
+                  :key="idx"
+                  xl="2"
+                  lg="3"
+                  md="4"
+                  sm="6"
+                  cols="6"
+                  min-height="50"
+                >
+                  <v-card hover="hover" @click="add_item(item)" class="item-card">
                   <v-img
                     :src="
                       item.image ||
@@ -153,12 +158,17 @@
                       </span>
                     </div>
                   </v-card-text>
-                </v-card>
-              </v-col>
-            </v-row>
+                  </v-card>
+                </v-col>
+              </v-row>
+            </div>
           </div>
-          <div class="items d-flex flex-column flex-grow-1" v-if="items_view == 'list'">
-            <div class="my-0 py-0 flex-grow-1 items-scrollable">
+          <div
+            class="items-panel d-flex flex-column flex-grow-1"
+            v-if="items_view == 'list'"
+          >
+            <!-- Scroll wrapper keeps table height capped -->
+            <div class="items-scrollable">
               <v-data-table
                 :headers="getItemsHeaders()"
                 :items="filtred_items"
@@ -1209,9 +1219,17 @@ export default {
   min-height: 0 !important;
 }
 
+.items-panel {
+  /* Panel keeps search zone fixed while body flexes */
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
 .items-scrollable {
   /* Scroll area for the grid/list */
   flex: 1 1 auto;
+  min-height: 0;
+  height: 100%;
   overflow-y: auto;
   max-height: 100%;
   padding-right: 4px;

--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -1100,6 +1100,7 @@ export default {
 <style scoped>
 .item-card {
   height: 100%;
+  min-height: 120px !important;
   display: flex;
   flex-direction: column;
 }
@@ -1109,6 +1110,7 @@ export default {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+  min-height: 60px !important;
 }
 
 .item-card .v-img {
@@ -1183,42 +1185,40 @@ export default {
   height: 28px !important;
 }
 
-/* Make ItemsSelector use full available space */
+.selection {
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 140px);
+  max-height: calc(100vh - 140px);
+  overflow: hidden;
+}
+
+.items {
+  flex: 1 1 auto !important;
+  min-height: 0 !important;
+}
+
 .items-scrollable {
-  min-height: 60vh !important;
-  height: auto !important;
+  flex: 1 1 auto;
+  overflow-y: auto;
+  max-height: 100%;
+  padding-right: 4px;
+  padding-bottom: 8px;
 }
 
 .items-scrollable .v-data-table__wrapper {
-  min-height: 60vh !important;
-  height: auto !important;
+  max-height: none;
 }
 
-/* Ensure proper spacing for card view */
 .items-scrollable .v-row {
-  min-height: 60vh !important;
-  height: auto !important;
+  margin: 0 !important;
 }
 
-/* Make parent containers use full space */
-.items {
-  min-height: 60vh !important;
-  height: auto !important;
-}
-
-.flex-grow-1 {
-  flex-grow: 1 !important;
-  min-height: 60vh !important;
-}
-
-/* Ensure card items take proper space */
-.item-card {
-  min-height: 120px !important;
-  height: auto !important;
-}
-
-.item-card .v-card__text {
-  min-height: 60px !important;
+@media (max-width: 960px) {
+  .selection {
+    height: calc(100vh - 200px);
+    max-height: calc(100vh - 200px);
+  }
 }
 
 .v-row {

--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -1,6 +1,7 @@
 <template>
   <!-- ===== TEMPLATE SECTION 1: MAIN CONTAINER ===== -->
-  <div>
+  <!-- Fixed-height wrapper keeps scroll inside -->
+  <div class="selector-wrapper">
 
   <!-- Filters and counters (no extra top margin) -->
     <v-card class="cards mb-2 pa-2 grey lighten-5">
@@ -1098,6 +1099,15 @@ export default {
 </script>
 
 <style scoped>
+.selector-wrapper {
+  /* Keep selector column inside viewport */
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 64px);
+  max-height: calc(100vh - 64px);
+  overflow: hidden;
+}
+
 .item-card {
   height: 100%;
   min-height: 120px !important;
@@ -1186,10 +1196,11 @@ export default {
 }
 
 .selection {
+  /* Let the selector card fill the wrapper */
   display: flex;
   flex-direction: column;
-  height: calc(100vh - 140px);
-  max-height: calc(100vh - 140px);
+  flex: 1 1 auto;
+  min-height: 0;
   overflow: hidden;
 }
 
@@ -1199,11 +1210,13 @@ export default {
 }
 
 .items-scrollable {
+  /* Scroll area for the grid/list */
   flex: 1 1 auto;
   overflow-y: auto;
   max-height: 100%;
   padding-right: 4px;
   padding-bottom: 8px;
+  overscroll-behavior: contain;
 }
 
 .items-scrollable .v-data-table__wrapper {
@@ -1215,9 +1228,16 @@ export default {
 }
 
 @media (max-width: 960px) {
-  .selection {
-    height: calc(100vh - 200px);
-    max-height: calc(100vh - 200px);
+  .selector-wrapper {
+    height: calc(100vh - 112px);
+    max-height: calc(100vh - 112px);
+  }
+}
+
+@media (max-width: 600px) {
+  .selector-wrapper {
+    height: calc(100vh - 160px);
+    max-height: calc(100vh - 160px);
   }
 }
 


### PR DESCRIPTION
## Summary
- raise the Vuetify app bar stacking context so the POS navbar stays above content while scrolling
- cap the item selector card height and add internal overflow scrolling for the grid/list views

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3802219248326a9d259635fb54303